### PR TITLE
Relink plugin to Qt framework that distributes with OBS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,14 @@ jobs:
           cd ./build
           make -j4
           cd -
+      - name: Relink to Qt that ships with OBS
+        if: success()
+        shell: bash
+        run: |
+          cd ./build/UI/frontend-plugins/${{ env.PLUGIN_NAME }}
+          install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ${{ env.PLUGIN_NAME }}.so
+          install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ${{ env.PLUGIN_NAME }}.so
+          install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ${{ env.PLUGIN_NAME }}.so
       - name: 'Install prerequisite: Packages app'
         if: success()
         shell: bash


### PR DESCRIPTION
This implements was @ucomesdag mentioned [here](https://github.com/exeldro/obs-media-controls/issues/2#issuecomment-663841246). The built output has been tested on macOS 10.13.6 (High Sierra) and macOS 10.15.16 (Catalina). This change seems to fix the issues on Catalina without breaking High Serra. Unfortunately, I don't have a way to confirm the build file still works on macOS 10.14 (Mojave).