### PR TITLE
Fixes #15, adjust macOS paths to Qt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,9 @@ jobs:
         shell: bash
         run: |
           cd ./build/UI/frontend-plugins/${{ env.PLUGIN_NAME }}
-          install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ${{ env.PLUGIN_NAME }}.so
-          install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ${{ env.PLUGIN_NAME }}.so
-          install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ${{ env.PLUGIN_NAME }}.so
+          install_name_tool -change /tmp/obsdeps/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ${{ env.PLUGIN_NAME }}.so
+          install_name_tool -change /tmp/obsdeps/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ${{ env.PLUGIN_NAME }}.so
+          install_name_tool -change /tmp/obsdeps/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ${{ env.PLUGIN_NAME }}.so
       - name: 'Install prerequisite: Packages app'
         if: success()
         shell: bash


### PR DESCRIPTION
Thank you for creating this plugin 👍 

When I tried to use it today after installing from media-controls-0.3.0-macos.pkg.zip, I noticed this load failure in my OBS logs:
```
11:10:04.115: os_dlopen(/Library/Application Support/obs-studio/plugins/media-controls/bin/media-controls.so->/Library/Application Support/obs-studio/plugins/media-controls/bin/media-controls.so): dlopen(/Library/Application Support/obs-studio/plugins/media-controls/bin/media-controls.so, 257): Library not loaded: /tmp/obsdeps/lib/QtWidgets.framework/Versions/5/QtWidgets
11:10:04.115:   Referenced from: /Library/Application Support/obs-studio/plugins/media-controls/bin/media-controls.so
11:10:04.115:   Reason: image not found
11:10:04.115: 
11:10:04.115: Module '/Library/Application Support/obs-studio/plugins/media-controls/bin/media-controls.so' not loaded
```

I believe this is likely the underlying problem with #15. When I inspected the library paths with otool, I saw paths for the Qt dependencies were still pointing to the tmp location used during the build:
```
otool -l '/Library/Application Support/obs-studio/plugins/media-controls/bin/media-controls.so'| grep tmp
         name /tmp/obsdeps/lib/QtWidgets.framework/Versions/5/QtWidgets (offset 24)
         name /tmp/obsdeps/lib/QtGui.framework/Versions/5/QtGui (offset 24)
         name /tmp/obsdeps/lib/QtCore.framework/Versions/5/QtCore (offset 24)
```

I see that the CI build script is already invoking `install_name_tool` to fix up these paths after the build and before packaging, it seems the path just didn't match the dependency path used earlier in the build. I created this temporary script to test the change to the paths, and after running this script against my local install, the plugin loads correctly and works great!
```
#!/usr/bin/env bash

PLUGIN='/Library/Application Support/obs-studio/plugins/media-controls/bin/media-controls.so'
OLD_PATH_PREFIX='/tmp/obsdeps/lib'
NEW_PATH_PREFIX='@executable_path/../Frameworks'
QT_WIDGETS='QtWidgets.framework/Versions/5/QtWidgets'
QT_GUI='QtGui.framework/Versions/5/QtGui'
QT_CORE='QtCore.framework/Versions/5/QtCore'


if ! otool -l "${PLUGIN}" | grep -q "${OLD_PATH_PREFIX}"; then
  echo "Old paths not found, nothing to do."
  exit 0
fi

echo "Found $OLD_PATH_PREFIX entries inside $PLUGIN, patching"

install_name_tool \
  -change "${OLD_PATH_PREFIX}/${QT_WIDGETS}" "${NEW_PATH_PREFIX}/${QT_WIDGETS}" \
  -change "${OLD_PATH_PREFIX}/${QT_GUI}" "${NEW_PATH_PREFIX}/${QT_GUI}" \
  -change "${OLD_PATH_PREFIX}/${QT_CORE}" "${NEW_PATH_PREFIX}/${QT_CORE}" \
  "${PLUGIN}"
```

I hope this PR is helpful and will make it easy to cut a new release that works on macOS. Let me know if you would like me to test the new release or do anything else to help.