### PR TITLE
Use updated version of msbuild action in CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
       WINDOWS_DEPS_VERSION: '2017'
     steps:
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Checkout obs
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
After submitting #16 I noticed the CI build was failing on windows, I think using this updated version of the msbuild setup action will help.