### PR TITLE
Fix cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
   target_link_libraries(${PROJECT_NAME} PRIVATE OBS::frontend-api)
 endif()
 
-find_package(Qt6 COMPONENTS Widgets Core)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Core)
 if(BUILD_OUT_OF_TREE)
   if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
     find_package(Qt6 REQUIRED Gui)
@@ -33,8 +33,9 @@ if(BUILD_OUT_OF_TREE)
 endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets)
 
-if((OS_LINUX OR OS_FREEBSD OR OS_OPENBSD) AND Qt_VERSION VERSION_LESS "6.9.0")
-	target_link_libraries(${PROJECT_NAME} PRIVATE Qt::GuiPrivate)
+if((OS_LINUX OR OS_FREEBSD OR OS_OPENBSD) AND Qt6_VERSION VERSION_LESS "6.9.0")
+  find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+  target_link_libraries(${PROJECT_NAME} PRIVATE Qt::GuiPrivate)
 endif()
 
 target_compile_options(


### PR DESCRIPTION
This PR fixes a cmake issue we encountered on Nixpkgs: https://github.com/NixOS/nixpkgs/pull/490666

The cmake configure phase was failing with:
```
-- Configuring done (2.5s)
CMake Error at CMakeLists.txt:37 (target_link_libraries):
  Target "media-controls" links to:

    Qt::GuiPrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY


CMake Generate step failed.  Build files cannot be regenerated correctly.
```
